### PR TITLE
Update to put unit files in correct location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,5 +28,5 @@ sudo -u $USER npx prisma migrate dev --name init
 sudo -u $USER sqlite3 ./prisma/dev.db 'PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;'
 
 # Install service files
-cp ./install/lotus-bot-*.service /etc/systemd/system
+mkdir -p $HOMEDIR/.config/systemd/user && cp ./install/lotus-bot-*.service $HOMEDIR/.config/systemd/user
 systemctl daemon-reload


### PR DESCRIPTION
Unit files for applications not related to system services should be in this folder.

New location: `$HOMEDIR/.config/systemd/user`

Since service is running AS lotus-bot, the full path would be `/opt/lotus-bot/.config/systemd/user`

Loading the service then changes to no longer require root access and can be loaded as: `systemctl --user start|stop|restart|status <serviceName>`