### PR TITLE
Prisma: get data only relevant to current platform

### DIFF
--- a/lib/lotusbot.ts
+++ b/lib/lotusbot.ts
@@ -84,7 +84,7 @@ export default class LotusBot {
 
   private _initWalletManager = async () => {
     try {
-      const keys = await this.prisma.getAllWalletKeys();
+      const keys = await this.prisma.getPlatformWalletKeys();
       if (keys.length < 1) {
         this._log(DB, 'initializing default bot account');
         await this._saveAccount({ platformId: this.botId, forBot: true });
@@ -110,7 +110,7 @@ export default class LotusBot {
       const utxos = this.wallets
         .getUtxos()
         .filter(utxo => utxo.userId != BOT.UUID);
-      const deposits = await this.prisma.getDeposits({});
+      const deposits = await this.prisma.getPlatformDeposits({});
       const newDeposits = utxos.filter(u => {
         const idx = deposits.findIndex(d => u.txid == d.txid);
         return idx < 0;
@@ -127,7 +127,9 @@ export default class LotusBot {
   private _initConfirmDeposits = async () => {
     this._log(MAIN, `confirming applicable deposits`);
     try {
-      const deposits = await this.prisma.getDeposits({ unconfirmed: true });
+      const deposits = await this.prisma.getPlatformDeposits({
+        unconfirmed: true
+      });
       for (const d of deposits) {
         const outpoint = WalletManager.toOutpoint(d);
         const [ result ] = await this.wallets.checkUtxosConfirmed([outpoint]);


### PR DESCRIPTION
Previous behavior was to get all WalletKeys and Deposits from the database. However, this could pose an issue in the situation where multiple instances of the bot are running (e.g. multiple Chronik WS subscriptions to the same Script causing the same deposit to be saved to the database, therefore causing a conflict and throwing an error)

This commit changes the behavior of the Prisma queries to poll only data associated with users of the current-running platform.