### PR TITLE
Load bot WalletKey on _initWalletManager()

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from "../prisma/prisma-client-js";
 import { PlatformDatabaseTable } from "./platforms";
 import { AccountUtxo } from "./wallet";
 import * as Util from '../util';
+import { BOT } from "../util/constants";
 
 type Deposit = AccountUtxo & {
   timestamp: Date,
@@ -45,6 +46,17 @@ export class Database {
   connect = async () => await this.prisma.$connect();
   disconnect = async () => await this.prisma.$disconnect();
 
+  botUserExists = async () => {
+    try {
+      const result = await this.prisma.user.findFirst({
+        where: { id: BOT.UUID }
+      });
+      return result?.id ? true : false;
+    } catch (e: any) {
+
+    }
+  };
+
   /** Check to make sure deposit exists. Used when confirming deposits. */
   isValidDeposit = async (
     txid: string
@@ -71,6 +83,19 @@ export class Database {
       return result?.userId ? true : false;
     } catch (e: any) {
       throw new Error(`isValidUser: ${e.message}`);
+    }
+  };
+  getBotWalletKey = async () => {
+    try {
+      const result = await this.prisma.walletKey.findFirst({
+        where: { userId: BOT.UUID }
+      });
+      return {
+        userId: result.userId,
+        hdPrivKey: result.hdPrivKey
+      };
+    } catch (e: any) {
+      throw new Error(`getBotWalletKey: ${e.message}`);
     }
   };
   /** Get WalletKeys for all platform users */


### PR DESCRIPTION
`platform-fixes-1` introduced a bug where the WalletKey for the bot would only be loaded on the first run; subsequent runs would skip loading the bot key.

This commit adds the conditional for properly loading the bot key on subsequent runs, and also adds methods to `database.ts` in order to handle this new logic.