### PR TITLE
Emit the Platform message with command data

### DIFF
--- a/lib/lotusbot.ts
+++ b/lib/lotusbot.ts
@@ -184,6 +184,7 @@ export default class LotusBot {
 
   private _handleBalanceCommand = async (
     platformId: string,
+    message?: Platforms.Message
   ) => {
     this._log(this.platform, `${platformId}: balance command received`);
     try {
@@ -194,6 +195,7 @@ export default class LotusBot {
       await this.bot.sendBalanceReply(
         platformId,
         Util.toLocaleXPI(balance),
+        message
       );
       this._log(
         this.platform,
@@ -206,6 +208,7 @@ export default class LotusBot {
   /** Gather user's address and send back to user as reply to their message */
   private _handleDepositCommand = async (
     platformId: string,
+    message?: Platforms.Message
   ) => {
     try {
       this._log(this.platform, `${platformId}: deposit command received`);
@@ -213,7 +216,7 @@ export default class LotusBot {
         ? await this._saveAccount({ platformId })
         : await this.prisma.getUserId(platformId);
       const address = this.wallets.getKey(userId)?.address?.toXAddress();
-      await this.bot.sendDepositReply(platformId, address);
+      await this.bot.sendDepositReply(platformId, address, message);
       this._log(this.platform, `${platformId}: deposit: address sent to user`);
     } catch (e: any) {
       throw new Error(`_platformHandleDeposit: ${e.message}`);
@@ -227,7 +230,8 @@ export default class LotusBot {
     fromUsername: string,
     toId: string,
     toUsername: string,
-    value: string
+    value: string,
+    message?: Platforms.Message
   ) => {
     try {
       const sats = Util.toSats(value);
@@ -272,7 +276,8 @@ export default class LotusBot {
         replyToMessageId,
         fromUsername,
         toUsername,
-        Util.toLocaleXPI(sats)
+        Util.toLocaleXPI(sats),
+        message
       );
       this._log(
         this.platform,
@@ -288,6 +293,7 @@ export default class LotusBot {
     platformId: string,
     wAmount: number,
     wAddress: string,
+    message?: Platforms.Message
   ) => {
     try {
       this._log(
@@ -342,7 +348,8 @@ export default class LotusBot {
       this._log(DB, `withdrawal saved: ${txid}`);
       await this.bot.sendWithdrawReply(
         platformId,
-        { txid, amount: Util.toLocaleXPI(wSats) }
+        { txid, amount: Util.toLocaleXPI(wSats) },
+        message
       );
       this._log(
         this.platform,

--- a/lib/platforms/index.ts
+++ b/lib/platforms/index.ts
@@ -1,8 +1,11 @@
-import { Telegram } from './telegram';
-import { Twitter } from './twitter';
+import { Telegram, TelegramMessage } from './telegram';
+import { Twitter, TwitterMessage } from './twitter';
 
 export { Telegram, Twitter };
 export type PlatformDatabaseTable = 'userTelegram' | 'userTwitter';
+export type Message =
+  | TelegramMessage
+  | TwitterMessage;
 
 export interface Platform {
   /**
@@ -17,8 +20,16 @@ export interface Platform {
   /** EventEmitter handlers */
   on: (event: string, callback: (...params: any) => void) => this;
   getBotId: () => string;
-  sendBalanceReply: (platformId: string, balance: string) => Promise<void>;
-  sendDepositReply: (platformId: string, address: string) => Promise<void>;
+  sendBalanceReply: (
+    platformId: string,
+    balance: string,
+    message?: Message
+   ) => Promise<void>;
+  sendDepositReply: (
+    platformId: string,
+    address: string,
+    message?: Message
+  ) => Promise<void>;
   sendDepositReceived: (
     platformId: string,
     txid: string,
@@ -35,7 +46,8 @@ export interface Platform {
     replyToMessageId: number,
     fromUsername: string,
     toUsername: string,
-    amount: string
+    amount: string,
+    message?: Message
   ) => Promise<void>;
   sendWithdrawReply: (
     platformId: string,
@@ -47,6 +59,7 @@ export interface Platform {
       txid?: string,
       amount?: string,
       error?: string
-    }
+    },
+    message?: Message
   ) => Promise<void>;
 };

--- a/lib/platforms/telegram.ts
+++ b/lib/platforms/telegram.ts
@@ -14,6 +14,8 @@ import {
 import config from '../../config'
 import { Message } from "telegraf/typings/core/types/typegram";
 
+export type TelegramMessage = Context;
+
 export declare interface Telegram {
   on(event: 'Balance', callback: (
     platformId: string

--- a/lib/platforms/twitter.ts
+++ b/lib/platforms/twitter.ts
@@ -1,6 +1,10 @@
 import { EventEmitter } from 'stream';
 import { Platform } from '.';
 
+export type TwitterMessage = {
+
+};
+
 export class Twitter
 extends EventEmitter
 implements Platform {


### PR DESCRIPTION
This commit adds functionality for Lotus Bot to be passed a message object through the EventEmitter specific to a platform. This message object is then passed back to the platform in the `send<Command>Reply` callbacks. This makes it easier for platforms to implement command replies.