### PR TITLE
Convert "Give" command to on-chain transaction

### DIFF
--- a/lib/lotusbot.ts
+++ b/lib/lotusbot.ts
@@ -8,7 +8,6 @@ import {
 import {
   Database,
 } from './database';
-import { BOT } from '../util/constants';
 
 // Constants used for logging purposes
 const WALLET = 'walletmanager';
@@ -43,25 +42,13 @@ export default class LotusBot {
       this._log(MAIN, 'shutting down');
       this._shutdown();
     }
-
     this.wallets.on('AddedToMempool', this._handleUtxoAddedToMempool);
     this.wallets.on('Confirmed', this._handleUtxoConfirmed);
     this.bot.on('Balance', this._handleBalanceCommand);
     this.bot.on('Deposit', this._handleDepositCommand);
     this.bot.on('Give', this._handleGiveCommand);
     this.bot.on('Withdraw', this._handleWithdrawCommand);
-
-    const utxoBalance = this.wallets.getUtxoBalance();
-    const botAddress = this.wallets.getBotAddress().toXAddress();
-    const initMsg =
-      `***\r\n` +
-      `* Lotus Bot has initialized successfully!\r\n` +
-      `* Total UTXO balance: ${utxoBalance} sats\r\n` +
-      `***\r\n` +
-      `* *NOTE*: Make sure you deposit at least 100 XPI to this address to\r\n` +
-      `*         pay withdrawal fees: ${botAddress}\r\n` +
-      `***`;
-    console.log(initMsg);
+    this._log(MAIN, "service initialized successfully");
   };
 
   private _initBot = async () => {
@@ -86,13 +73,6 @@ export default class LotusBot {
   private _initWalletManager = async () => {
     try {
       const keys = await this.prisma.getPlatformWalletKeys();
-      if (!(await this.prisma.botUserExists())) {
-        this._log(DB, 'initializing default bot account');
-        await this._saveAccount({ forBot: true });
-      } else {
-        const { userId, hdPrivKey } = await this.prisma.getBotWalletKey();
-        keys.push({ userId, hdPrivKey });
-      }
       await this.wallets.init(
         keys.map(key => {
           const { userId, hdPrivKey } = key;
@@ -111,9 +91,7 @@ export default class LotusBot {
   private _initReconcileDeposits = async () => {
     this._log(MAIN, `reconciling deposits with UTXO set`);
     try {
-      const utxos = this.wallets
-        .getUtxos()
-        .filter(utxo => utxo.userId != BOT.UUID);
+      const utxos = this.wallets.getUtxos();
       const deposits = await this.prisma.getPlatformDeposits({});
       const newDeposits = utxos.filter(u => {
         const idx = deposits.findIndex(d => u.txid == d.txid);
@@ -165,6 +143,13 @@ export default class LotusBot {
     const utxoString = JSON.stringify(utxo);
     try {
       this._log(WALLET, `deposit received: ${utxoString}`);
+      if (
+        await this.prisma.isGiveTx(utxo.txid) ||
+        await this.prisma.isWithdrawTx(utxo.txid)
+      ) {
+        this._log(DB, `deposit is a Give/Withdraw tx: skipping: ${utxo.txid}`);
+        return;
+      }
       await this._saveDeposit(utxo);
     } catch (e: any) {
       throw new Error(`_handleUtxoAddedToMempool: ${e.message}`);
@@ -176,6 +161,13 @@ export default class LotusBot {
   ) => {
     try {
       this._log(WALLET, `deposit confirmed: ${txid}`);
+      if (!(await this.prisma.isValidDeposit(txid))) {
+        this._log(
+          DB,
+          `deposit invalid (likely Give/Withdraw tx): skipping: ${txid}`
+        );
+        return;
+      }
       await this._confirmDeposit(txid);
     } catch (e: any) {
       throw new Error(`_handleUtxoConfirmed: ${e.message}`);
@@ -188,10 +180,10 @@ export default class LotusBot {
   ) => {
     this._log(this.platform, `${platformId}: balance command received`);
     try {
-      if (!(await this.prisma.isValidUser(platformId))) {
-        await this._saveAccount({ platformId });
-      }
-      const balance = await this.prisma.getAccountBalance(platformId);
+      const userId = !(await this.prisma.isValidUser(platformId))
+        ? await this._saveAccount(platformId)
+        : await this.prisma.getUserId(platformId);
+      const balance = await this.wallets.getUserBalance(userId);
       await this.bot.sendBalanceReply(
         platformId,
         Util.toLocaleXPI(balance),
@@ -213,7 +205,7 @@ export default class LotusBot {
     try {
       this._log(this.platform, `${platformId}: deposit command received`);
       const userId = !(await this.prisma.isValidUser(platformId))
-        ? await this._saveAccount({ platformId })
+        ? await this._saveAccount(platformId)
         : await this.prisma.getUserId(platformId);
       const address = this.wallets.getKey(userId)?.address?.toXAddress();
       await this.bot.sendDepositReply(platformId, address, message);
@@ -237,29 +229,34 @@ export default class LotusBot {
       const sats = Util.toSats(value);
       this._log(
         this.platform,
-        `give: ${fromId}: ${fromUsername} -> ${toUsername}: ${sats} sats`
+        `${fromId}: give: ${fromUsername} -> ${toUsername}: ${sats} sats`
       );
       // Create account for fromId if not exist
       const fromUserId = !(await this.prisma.isValidUser(fromId))
-        ? await this._saveAccount({ platformId: fromId })
+        ? await this._saveAccount(fromId)
         : await this.prisma.getUserId(fromId);
-      const balance = await this.prisma.getAccountBalance(fromId);
+      const balance = await this.wallets.getUserBalance(fromUserId);
       if (sats > balance) {
         this._log(
           this.platform,
-          `give: ${fromUsername} -> ${toUsername}: ` +
+          `${fromId}: give: ${fromUsername} -> ${toUsername}: ` +
           `insufficient balance: ${sats} > ${balance}`
         );
         return;
       }
       // Create account for toId if not exist
       const toUserId = !(await this.prisma.isValidUser(toId))
-        ? await this._saveAccount({ platformId: toId })
+        ? await this._saveAccount(toId)
         : await this.prisma.getUserId(toId);
-      // Give successful; save to db
+      // Give successful; broadcast tx and save to db
+      const txid = await this.wallets.processTx({
+        fromUserId,
+        toUserId,
+        sats
+      });
       const timestamp = new Date();
       await this.prisma.saveGive({
-        id: Util.newUUID(),
+        txid,
         platform: this.platform.toLowerCase(),
         timestamp,
         fromId: fromUserId,
@@ -268,7 +265,8 @@ export default class LotusBot {
       });
       this._log(
         DB,
-        `${this.platform}: give saved: ${fromUsername} -> ${toUsername}`
+        `${this.platform}: give saved: ${fromUsername} -> ${toUsername}: ` +
+        txid
         );
       // Send Give success reply to chat
       await this.bot.sendGiveReply(
@@ -276,12 +274,13 @@ export default class LotusBot {
         replyToMessageId,
         fromUsername,
         toUsername,
+        txid,
         Util.toLocaleXPI(sats),
         message
       );
       this._log(
         this.platform,
-        `give: ${fromId}: ${fromUsername} -> ${toUsername}: ` +
+        `${fromId}: give: ${fromUsername} -> ${toUsername}: ` +
         `${sats} sats: success: notified user in group`
       );
     } catch (e: any) {
@@ -292,18 +291,18 @@ export default class LotusBot {
   private _handleWithdrawCommand = async (
     platformId: string,
     wAmount: number,
-    wAddress: string,
+    outAddress: string,
     message?: Platforms.Message
   ) => {
     try {
       this._log(
         this.platform,
-        `${platformId}: withdraw command received: ${wAmount} ${wAddress}`
+        `${platformId}: withdraw command received: ${wAmount} ${outAddress}`
       );
-      if (!WalletManager.isValidAddress(wAddress)) {
+      if (!WalletManager.isValidAddress(outAddress)) {
         this._log(
           this.platform,
-          `${platformId}: withdraw: invalid address: ${wAddress}`
+          `${platformId}: withdraw: invalid address: ${outAddress}`
         );
         return await this.bot.sendWithdrawReply(
           platformId,
@@ -320,22 +319,26 @@ export default class LotusBot {
           { error: `amount invalid` }
         );
       }
-      const wSats = Util.toSats(wAmount);
-      if (!(await this.prisma.isValidUser(platformId))) {
-        await this._saveAccount({ platformId });
-      }
-      const balance = await this.prisma.getAccountBalance(platformId);
+      const sats = Util.toSats(wAmount);
+      const fromUserId = !(await this.prisma.isValidUser(platformId))
+        ? await this._saveAccount(platformId)
+        : await this.prisma.getUserId(platformId);
+      const balance = await this.wallets.getUserBalance(fromUserId);
       if (wAmount > balance) {
         this._log(
           this.platform,
-          `${platformId}: withdraw: insufficient balance: ${wSats} > ${balance}`
+          `${platformId}: withdraw: insufficient balance: ${sats} > ${balance}`
         );
         return await this.bot.sendWithdrawReply(
           platformId,
           { error: 'insufficient balance' }
         );
       }
-      const txid = await this.wallets.processWithdrawal(wAddress, wSats);
+      const txid = await this.wallets.processTx({
+        fromUserId,
+        outAddress,
+        sats
+      });
       this._log(WALLET, `withdrawal accepted: ${txid}`);
       const timestamp = new Date();
       const userId = await this.prisma.getUserId(platformId);
@@ -348,15 +351,13 @@ export default class LotusBot {
       this._log(DB, `withdrawal saved: ${txid}`);
       await this.bot.sendWithdrawReply(
         platformId,
-        { txid, amount: Util.toLocaleXPI(wSats) },
+        { txid, amount: Util.toLocaleXPI(sats) },
         message
       );
       this._log(
         this.platform,
-        `${platformId}: withdraw: user notified of success: ${wSats} sats`
+        `${platformId}: withdraw: user notified of success: ${sats} sats`
       );
-      const totalUtxoBalance = this.wallets.getUtxoBalance();
-      this._log(WALLET, `total UTXO balance: ${totalUtxoBalance} sats`);
     } catch (e: any) {
       throw new Error(`_handleWithdrawCommand: ${e.message}`);
     }
@@ -367,16 +368,12 @@ export default class LotusBot {
    * - Load new account `WalletKey` into WalletManager
    * - Return `userId` and `key` from saved account
    */
-  private _saveAccount = async ({
-    platformId,
-    forBot
-  }: {
-    platformId?: string,
-    forBot?: boolean
-  }) => {
+  private _saveAccount = async (
+    platformId: string
+  ) => {
     try {
-      const accountId = forBot ? BOT.UUID : Util.newUUID();
-      const userId = forBot ? BOT.UUID : Util.newUUID();
+      const accountId = Util.newUUID();
+      const userId = Util.newUUID();
       const mnemonic = WalletManager.newMnemonic();
       const hdPrivKey = WalletManager.newHDPrivateKey(mnemonic);
       const hdPubKey = hdPrivKey.hdPublicKey;
@@ -400,15 +397,9 @@ export default class LotusBot {
   private _saveDeposit = async (
     utxo: AccountUtxo
   ) => {
-    const timestamp = new Date();
-    const data = { ...utxo, timestamp };
     try {
-      const totalUtxoBalance = this.wallets.getUtxoBalance();
-      this._log(WALLET, `total UTXO balance: ${totalUtxoBalance} sats`);
-      if (utxo.userId == BOT.UUID) {
-        this._log(DB, `deposit is for bot address: skipping`);
-        return;
-      }
+      const timestamp = new Date();
+      const data = { ...utxo, timestamp };
       const deposit = await this.prisma.saveDeposit(data);
       const platformId = deposit.user[this.platform.toLowerCase()].id;
       this._log(DB, `deposit saved: ${utxo.txid}`);
@@ -430,14 +421,10 @@ export default class LotusBot {
     txid: string
   ) => {
     try {
-      if (!(await this.prisma.isValidDeposit(txid))) {
-        this._log(DB, `deposit invalid (likely bot txid): skipping`);
-        return;
-      }
       const { user, value } = await this.prisma.confirmDeposit(txid);
       const platformId = user[this.platform.toLowerCase()].id;
       this._log(DB, `deposit confirmed: ${txid}`);
-      const balance = await this.prisma.getAccountBalance(platformId);
+      const balance = await this.wallets.getUserBalance(user.id);
       await this.bot.sendDepositConfirmed(
         platformId,
         txid,

--- a/lib/platforms/discord.ts
+++ b/lib/platforms/discord.ts
@@ -253,6 +253,7 @@ implements Platform {
     replyToMessageId: number,
     fromUsername: string,
     toUsername: string,
+    txid: string,
     amount: string,
     interaction: ChatInputCommandInteraction
   ) => {

--- a/lib/platforms/telegram.ts
+++ b/lib/platforms/telegram.ts
@@ -75,7 +75,8 @@ implements Platform {
     replyToMessageId: number,
     fromUsername: string,
     toUsername: string,
-    amount: string
+    txid: string,
+    amount: string,
   ) => {
     try {
       await setTimeout(this._calcReplyDelay());
@@ -83,10 +84,12 @@ implements Platform {
         BOT.MESSAGE.GIVE,
         fromUsername,
         amount,
-        toUsername
+        toUsername,
+        `${config.wallet.explorerUrl}/tx/${txid}`
       );
       await this.bot.telegram.sendMessage(chatId, msg, {
-        reply_to_message_id: replyToMessageId
+        reply_to_message_id: replyToMessageId,
+        parse_mode: 'Markdown'
       });
       this.lastReplyTime = Date.now();
     } catch (e: any) {

--- a/lib/platforms/twitter.ts
+++ b/lib/platforms/twitter.ts
@@ -30,7 +30,8 @@ implements Platform {
     replyToMessageId: number,
     fromUsername: string,
     toUsername: string,
-    amount: string
+    txid: string,
+    amount: string,
   ) => Promise<void>;
   sendWithdrawReply: (
     platformId: string,

--- a/schema.prisma
+++ b/schema.prisma
@@ -33,7 +33,7 @@ model Withdrawal {
 }
 
 model Give {
-  id String @id
+  txid String @unique
   platform String
   timestamp DateTime
   fromId String

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -3,7 +3,6 @@ export const XPI_DIVISOR = 1000000;
 
 // Default bot database properties
 export const BOT = {
-  UUID: "00000000-0000-0000-0000-000000000000",
   MESSAGE: {
     ERR_DM_COMMAND: 'Please send me this command in a DM',
     ERR_NOT_DM_COMMAND: 'This command does not work in a DM',
@@ -12,7 +11,9 @@ export const BOT = {
     ERR_AMOUNT_INVALID: 'Invalid amount specified',
     ERR_GIVE_TO_BOT:
       'I appreciate the thought, but you cannot give me Lotus. :)',
-    GIVE: '%s, you have given %s XPI to %s! 🪷',
+    GIVE:
+      `%s, you have given %s XPI to %s! 🪷\r\n\r\n` +
+      `[View tx on the Explorer](%s)`,
     RECEIVE: `%s, you have received %s XPI from %s! 🪷`,
     BALANCE: 'Your balance is %s XPI',
     DEPOSIT:


### PR DESCRIPTION
This commit overhauls the LotusBot and WalletManager modules. When a platform user issues the "Give" command, the transaction now occurs on-chain vs. simply creating an entry in the database. Due to this, all user balances are determined by the WalletManager.

The database Give schema has been updated to accommodate the txid of a Give.

The platforms and the Platform interface were updated to receive the txid from LotusBot after an on-chain give is successful. This allows the platform to send the txid with its "give successful" message.

Several other tweaks are included in this commit, e.g. removing the Bot account, adding a `_reconcileUtxos` method to WalletManager (for ensuring user UTXOs are valid before balance is calculated), updated logic for the Chronik WS handler, etc.