### PR TITLE
Remove all tx confirmation logic

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -77,20 +77,6 @@ export class Database {
       throw new Error(`isWithdrawTx: ${e.message}`);
     }
   }
-  /** Check to make sure deposit exists. Used when confirming deposits. */
-  isValidDeposit = async (
-    txid: string
-  ): Promise<boolean> => {
-    try {
-      const result = await this.prisma.deposit.findFirst({
-        where: { txid },
-        select: { txid: true }
-      });
-      return result?.txid ? true : false;
-    } catch (e: any) {
-      throw new Error(`isValidDeposit: ${e.message}`);
-    }
-  };
 
   /** Check db to ensure `userId` exists */
   isValidUser = async (
@@ -126,17 +112,11 @@ export class Database {
     }
   };
   /** Get all deposits or all unconfirmed deposits of platform users */
-  getPlatformDeposits = async ({
-    unconfirmed = false
-  }: {
-    unconfirmed?: boolean
-  }) => {
+  getPlatformDeposits = async () => {
     try {
       const result = await this.prisma[this.platformTable].findMany({
         select: { user: {
-          select: { deposits: {
-            where: unconfirmed ? { confirmed: false } : undefined
-          }}
+          select: { deposits: true }
         }}
       });
       const deposits: Deposit[] = [];

--- a/lib/platforms/discord.ts
+++ b/lib/platforms/discord.ts
@@ -206,7 +206,8 @@ implements Platform {
   sendDepositReceived = async (
     platformId: string,
     txid: string,
-    amount: string
+    amount: string,
+    balance: string,
   ) => {
     try {
       const embedMessage = new EmbedBuilder()

--- a/lib/platforms/index.ts
+++ b/lib/platforms/index.ts
@@ -35,11 +35,6 @@ export interface Platform {
   sendDepositReceived: (
     platformId: string,
     txid: string,
-    amount: string
-  ) => Promise<void>;
-  sendDepositConfirmed: (
-    platformId: string,
-    txid: string,
     amount: string,
     balance: string
   ) => Promise<void>;

--- a/lib/platforms/telegram.ts
+++ b/lib/platforms/telegram.ts
@@ -149,13 +149,15 @@ implements Platform {
   sendDepositReceived = async (
     platformId: string,
     txid: string,
-    amount: string
+    amount: string,
+    balance: string,
   ) => {
     try {
       await setTimeout(this._calcReplyDelay());
       const msg = format(
         BOT.MESSAGE.DEPOSIT_RECV,
         amount,
+        balance,
         `${config.wallet.explorerUrl}/tx/${txid}`
       );
       await this.bot.telegram.sendMessage(platformId, msg,

--- a/lib/platforms/twitter.ts
+++ b/lib/platforms/twitter.ts
@@ -17,7 +17,8 @@ implements Platform {
   sendDepositReceived: (
     platformId: string,
     txid: string,
-    amount: string
+    amount: string,
+    balance: string,
   ) => Promise<void>;
   sendDepositConfirmed: (
     platformId: string,

--- a/schema.prisma
+++ b/schema.prisma
@@ -18,9 +18,8 @@ model Deposit {
   value String
   userId String
   timestamp DateTime
-  confirmed Boolean @default(false)
   user User @relation(fields: [userId], references: [id])
-  @@index([txid, userId, confirmed])
+  @@index([txid, userId])
 }
 
 model Withdrawal {

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -21,7 +21,7 @@ export const BOT = {
       `[View address on the Explorer](%s)`,
     DEPOSIT_RECV:
       `I received your deposit of %s XPI. ` +
-      `I will let you know when it confirms.\r\n\r\n` +
+      `Your balance is now %s XPI.\r\n\r\n` +
       `[View tx on the Explorer](%s)`,
     DEPOSIT_CONF: 
       `Your deposit of %s XPI has been confirmed! ` +


### PR DESCRIPTION
The confirmation logic was implemented so that users could not give or withdraw Lotus without their deposit having first confirmed. Since v2.0.0, Give interactions are now on-chain. This created a problem where gives would trigger the Chronik `AddedToMempool` and be subject to the same confirmation logic as deposits. However, this is terrible for the expected UX, where gives are immediately re-givable.

Operating on 0-conf creates a potential double-spend DoS vector, where a depositing user double-spends their deposit, thereby causing the bot to retain an invalid UTXO in their set. However, this DoS vector is mitigated with the `WalletManager._reconcileUtxos` method, which runs at the same time `WalletManager.getUserBalanace` runs.