### PR TITLE
bugfix: don't allow give to self

### DIFF
--- a/lib/platforms/discord.ts
+++ b/lib/platforms/discord.ts
@@ -370,6 +370,13 @@ implements Platform {
             });
             break;
           }
+          // can't send to self
+          if (platformId == toId) {
+            await interaction.reply({
+              content: BOT.MESSAGE.ERR_MUST_GIVE_TO_OTHER_USER
+            });
+            break;
+          }
           if (this.clientId == to.id) {
             await interaction.reply({
               content: format(BOT.MESSAGE.ERR_GIVE_TO_BOT),

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -6,6 +6,7 @@ export const BOT = {
   MESSAGE: {
     ERR_DM_COMMAND: 'Please send me this command in a DM',
     ERR_NOT_DM_COMMAND: 'This command does not work in a DM',
+    ERR_MUST_GIVE_TO_OTHER_USER: 'You cannot give Lotus to yourself. :)',
     ERR_GIVE_MUST_REPLY_TO_USER:
       'You must reply to another user to give Lotus',
     ERR_AMOUNT_INVALID: 'Invalid amount specified',


### PR DESCRIPTION
Previous behavior allowed a user to give Lotus to themselves, resulting in a transaction that sent Lotus to their own address and paid the fees to do so. This commit adds the conditional to check that the from and to IDs are not the same.