### PR TITLE
bugfix: premature return from Chronik WS handler

### DIFF
--- a/lib/wallet.ts
+++ b/lib/wallet.ts
@@ -366,7 +366,8 @@ export class WalletManager extends EventEmitter {
             break;
           }
           this.keys[userId].utxos.push(parsedUtxo);
-          return this.emit('AddedToMempool', { ...parsedUtxo, userId });
+          this.emit('AddedToMempool', { ...parsedUtxo, userId });
+          break;
         }
       }
     } catch (e: any) {


### PR DESCRIPTION
`_chronikHandleWsMessage` method was returning on emit, but this could skip saving utxos for other local addresses that were involved in the tx (i.e. a give tx usually adds 2 utxos). This commit removes the premature return to ensure all utxos of a tx are processed accordingly.