### PR TITLE
adjust amount check conditional

### DIFF
--- a/lib/wallet.ts
+++ b/lib/wallet.ts
@@ -220,7 +220,7 @@ export class WalletManager extends EventEmitter {
           }
         }
         // May need to continue adding utxos from other keys
-        if (tx.inputAmount <= outSats) {
+        if (tx.inputAmount < outSats) {
           continue;
         }
         const outScript = this._getScriptFromAddress(outAddress);


### PR DESCRIPTION
Behavior was observed where a user attempting to withdraw their entire wallet balance would cause an error to be thrown. This error was caused by a conditional that was not allowing the tx to be crafted if the withdraw amount equaled their total balance. This commit fixes the conditional to ensure the tx gets created before broadcasting.