### PR TITLE
only init/shutdown enabled platforms

### DIFF
--- a/lib/platforms/index.ts
+++ b/lib/platforms/index.ts
@@ -2,7 +2,11 @@ import { Telegram, TelegramMessage } from './telegram';
 import { Twitter, TwitterMessage } from './twitter';
 import { Discord, DiscordMessage } from './discord';
 
-export { Telegram, Twitter, Discord };
+export const Platforms = {
+  telegram: Telegram,
+  twitter: Twitter,
+  discord: Discord
+};
 export type PlatformName = 'telegram' | 'twitter' | 'discord';
 export type PlatformDatabaseTable = 'userTelegram' | 'userTwitter' | 'userDiscord';
 export type PlatformMessage =


### PR DESCRIPTION
Previous behavior attempted to configure all available platforms. This would throw errors in cases where all available platforms are not enabled. This commit fixes this behavior so that only enabled platforms are initialized and maintained during runtime, and ensures only these platforms are shutdown on `SIGINT`.