### PR TITLE
Implement `backup` command

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -154,6 +154,25 @@ export class Database {
       throw new Error(`getUserSecret: ${e.message}`);
     }
   };
+  getUserMnemonic = async (
+    platform: string,
+    platformId: string
+  ) => {
+    const platformTable = this._toPlatformTable(platform);
+    try {
+      const result = await this.prisma[platformTable].findFirst({
+        where: { id: platformId },
+        select: { user: {
+          select: { key: {
+            select: { mnemonic: true }
+          }}
+        }}
+      });
+      return result.user.key.mnemonic;
+    } catch (e: any) {
+      throw new Error(`getUserMnemonic: ${e.message}`);
+    }
+  };
   /**
    * Save new `Account` to the database  
    * Also saves all associated data (e.g. Platform, WalletKey, etc.)

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -155,20 +155,16 @@ export class Database {
     }
   };
   getUserMnemonic = async (
-    platform: string,
-    platformId: string
+    userId: string
   ) => {
-    const platformTable = this._toPlatformTable(platform);
     try {
-      const result = await this.prisma[platformTable].findFirst({
-        where: { id: platformId },
-        select: { user: {
-          select: { key: {
-            select: { mnemonic: true }
-          }}
+      const result = await this.prisma.user.findFirst({
+        where: { id: userId },
+        select: { key: { 
+          select: { mnemonic: true }
         }}
       });
-      return result.user.key.mnemonic;
+      return result.key.mnemonic
     } catch (e: any) {
       throw new Error(`getUserMnemonic: ${e.message}`);
     }

--- a/lib/lotusbot.ts
+++ b/lib/lotusbot.ts
@@ -522,8 +522,8 @@ export default class LotusBot {
     const msg = `${platformId}: backup: `;
     this._log(platform, `${platformId}: backup command received`);
     try {
-      await this._checkAccountValid(platform, platformId);
-      const mnemonic = await this.prisma.getUserMnemonic(platform, platformId);
+      const { userId } = await this._checkAccountValid(platform, platformId);
+      const mnemonic = await this.prisma.getUserMnemonic(userId);
       try {
         await this.bots[platform].sendBackupReply(platformId, mnemonic, message);
         this._log(platform, msg + `user notified`);

--- a/lib/lotusbot.ts
+++ b/lib/lotusbot.ts
@@ -68,7 +68,8 @@ export default class LotusBot {
       this.bots[name].on('Give', this._handleGiveCommand);
       this.bots[name].on('Withdraw', this._handleWithdrawCommand);
       this.bots[name].on('Link', this._handleLinkCommand);
-    })
+      this.bots[name].on('Backup', this._handleBackupCommand);
+    });
     this._log(MAIN, "service initialized successfully");
   };
   /**
@@ -509,6 +510,27 @@ export default class LotusBot {
       }
     } catch (e: any) {
       this._log(MAIN, `FATAL: _handleLinkCommand: ${e.message}`);
+      await this._shutdown();
+    }
+  };
+
+  private _handleBackupCommand = async (
+    platform: PlatformName,
+    platformId: string,
+    message?: PlatformMessage
+  ) => {
+    const msg = `${platformId}: backup: `;
+    this._log(platform, `${platformId}: backup command received`);
+    try {
+      const mnemonic = await this.prisma.getUserMnemonic(platform, platformId);
+      try {
+        await this.bots[platform].sendBackupReply(platformId, mnemonic, message);
+        this._log(platform, msg + `user notified`);
+      } catch (e: any) {
+        return this._logPlatformNotifyError(platform, msg, e.message)
+      }
+    } catch (e: any) {
+      this._log(MAIN, `FATAL: _handleBackupCommand: ${e.message}`);
       await this._shutdown();
     }
   };

--- a/lib/lotusbot.ts
+++ b/lib/lotusbot.ts
@@ -522,6 +522,7 @@ export default class LotusBot {
     const msg = `${platformId}: backup: `;
     this._log(platform, `${platformId}: backup command received`);
     try {
+      await this._checkAccountValid(platform, platformId);
       const mnemonic = await this.prisma.getUserMnemonic(platform, platformId);
       try {
         await this.bots[platform].sendBackupReply(platformId, mnemonic, message);

--- a/lib/platforms/discord.ts
+++ b/lib/platforms/discord.ts
@@ -126,6 +126,10 @@ implements Platform {
         ],
       },
       {
+        name: 'backup',
+        description: 'Back up the seed phrase for this platform'
+      },
+      {
         name: 'ping',
         description: 'pong'
       },

--- a/lib/platforms/discord.ts
+++ b/lib/platforms/discord.ts
@@ -292,6 +292,22 @@ implements Platform {
       throw new Error(`sendLinkReply: ${e.message}`);
     }
   };
+
+  sendBackupReply = async (
+    platformId: string,
+    mnemonic: string,
+    interaction: DiscordMessage
+  ) => {
+    try {
+      await interaction.reply({
+        content: format(BOT.MESSAGE.BACKUP, mnemonic),
+        ephemeral: true
+      });
+    } catch (e: any) {
+      throw new Error(`sendBackupReply: ${e.message}`);
+    }
+  };
+
   private _registerCommands = async (guildId: string) => {
     try {
       await this.client.rest.put(
@@ -345,13 +361,17 @@ implements Platform {
       case 'link':
         this.emit('Link', 'discord', author.id, secret, message);
         break;
+      case 'backup':
+        this.emit('Backup', 'discord', author.id, message);
+        break;
       default:
         message.reply(
           `You can only use the following verbs in my DMs:\r\n\r\n` +
           `**balance** - Get your current balance in the bot.\r\n` +
           `**deposit** - Get the address needed to deposit XPI.\r\n` +
           `**withdraw** - Withdraw XPI to an external wallet.\r\n` +
-          '**link** - Link to another account/platform\r\n\r\n' +
+          '**link** - Link to another account/platform\r\n' +
+          `**backup** - Get the seed phrase of your bot wallet\r\n\r\n` +
           "withdraw command syntax: `withdraw <amount> <external_address>`\r\n" +
           "link command syntax:\r\n" +
           "```link <secret code> - Link using code from other acocunt\r\n" +
@@ -448,6 +468,9 @@ implements Platform {
         case 'link':
           const secret = options.getString('secret') || undefined;
           this.emit('Link', 'discord', platformId, secret, interaction);
+          break;
+        case 'backup':
+          this.emit('Backup', 'discord', platformId, interaction);
           break;
         case "ping":
           await interaction.reply({ content: `Pong! 🏓` });

--- a/lib/platforms/index.ts
+++ b/lib/platforms/index.ts
@@ -58,6 +58,11 @@ export interface Platform {
     secret: string | undefined,
     message?: PlatformMessage
   ) => void): this;
+  on(event: 'Backup', callback: (
+    platform: PlatformName,
+    platformId: string,
+    message?: PlatformMessage
+  ) => void): this;
   /**
    * Send reply to the `balance` command to `platformId`  
    * Optionally use the `PlatformMessage` object to send reply
@@ -122,6 +127,15 @@ export interface Platform {
   sendLinkReply: (
     platformId: string,
     { error, secret }: { error?: string, secret?: string },
+    message?: PlatformMessage
+  ) => Promise<void>;
+  /**
+   * Send reply to the `backup` command to `platformId`  
+   * Optionally use the `PlatformMessage` object to send reply
+   */
+  sendBackupReply: (
+    platformId: string,
+    mnemonic: string,
     message?: PlatformMessage
   ) => Promise<void>;
 };

--- a/lib/platforms/telegram.ts
+++ b/lib/platforms/telegram.ts
@@ -63,6 +63,7 @@ implements Platform {
     this.bot.command('deposit', this._handleDirectMessage);
     this.bot.command('withdraw', this._handleDirectMessage);
     this.bot.command('link', this._handleDirectMessage);
+    this.bot.command('backup', this._handleDirectMessage);
     this.bot.start(this._handleDirectMessage);
   };
   launch = async () => {
@@ -235,6 +236,23 @@ implements Platform {
     }
   };
 
+  sendBackupReply = async (
+    platformId: string,
+    mnemonic: string
+  ) => {
+    try {
+      await setTimeout(this._calcReplyDelay());
+      await this.bot.telegram.sendMessage(
+        platformId,
+        format(BOT.MESSAGE.BACKUP, mnemonic),
+        { parse_mode: 'Markdown' }
+      );
+      this.lastReplyTime = Date.now();
+    } catch (e: any) {
+      throw new Error(`sendBackupReply: ${e.message}`);
+    }
+  };
+
   private _handleDirectMessage = async (
     ctx: TelegramMessage
   ) => {
@@ -277,6 +295,8 @@ implements Platform {
         case '/link':
           const secret = parseLink(messageText);
           return this.emit('Link', 'telegram', platformId, secret);
+        case '/backup':
+          return this.emit('Backup', 'telegram', platformId);
         case '/start':
           return ctx.sendMessage(
             `Welcome to my home! ` +

--- a/lib/platforms/twitter.ts
+++ b/lib/platforms/twitter.ts
@@ -52,4 +52,8 @@ implements Platform {
   ) => {
 
   };
+  sendBackupReply: (
+    platformId: string,
+    mnemonic: string,
+  ) => Promise<void>;
 };

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -40,6 +40,13 @@ export const BOT = {
       `command and I will link your accounts together.`,
     LINK_OK: `Your accounts have now been linked! `,
     LINK_FAIL: `There was an error linking your account: %s`,
+    BACKUP:
+      `Your seed phrase is: \`%s\`\r\n\r\n` +
+      `WARNING: If you have linked platform accounts, then the balance in ` +
+      `this wallet may not reflect your total account balance. If you send ` +
+      `Lotus from this wallet, it WILL be reflected in your total account ` +
+      `balance. If you send Lotus to this wallet, you will receive a deposit ` +
+      `notification.`
   },
 };
 


### PR DESCRIPTION
This commit adds the `backup` command for platforms Telegram and Discord. `backup` allows platform users to dump their wallet seed phrase associated with the platform account for use in external wallets (e.g. sendlotus.com).