### PR TITLE
Revert telegraf upgrade to 4.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -773,18 +773,18 @@
       }
     },
     "node_modules/telegraf": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.12.2.tgz",
-      "integrity": "sha512-PgwqI4wD86cMqVfFtEM9JkGGnMHgvgLJbReZMmwW4z35QeOi4DvbdItONld4bPnYn3A1jcO0SRKs0BXmR+x+Ew==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.11.2.tgz",
+      "integrity": "sha512-RGEh+NXkHbq1KcSSbJeVYhHMrEN4rymd9DSe3SoIV0886bJPBHLzYCNrOqnk9aeZE2Idwh5uK0X/xbR6jScQKQ==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "debug": "^4.3.4",
         "mri": "^1.2.0",
-        "node-fetch": "^2.6.8",
+        "node-fetch": "^2.6.7",
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
         "sandwich-stream": "^2.0.2",
-        "typegram": "^4.3.0"
+        "typegram": "^4.1.0"
       },
       "bin": {
         "telegraf": "lib/cli.mjs"


### PR DESCRIPTION
There seems to be a bug in telegraf 4.12.2 that prevents the bot from launching. This commit downgrades telegraf back to 4.11.2.